### PR TITLE
 Allow null to be returned by getUsername(), getPassword()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-    "name": "webignition/simplytestable-userm-interface",
+    "name": "webignition/simplytestable-user-interface",
     "description": "",
-    "keywords": [,
+    "keywords": [],
     "homepage": "https://github.com/webignition/simplytestable-user-interface",
     "type": "library",
     "license": "MIT",

--- a/src/UserInterface.php
+++ b/src/UserInterface.php
@@ -5,8 +5,8 @@ namespace webignition\SimplyTestableUserInterface;
 interface UserInterface
 {
     public function setUsername(string $username);
-    public function getUsername(): string;
+    public function getUsername(): ?string;
     public function setPassword(string $password);
-    public function getPassword(): string;
+    public function getPassword(): ?string;
     public function equals(UserInterface $user): bool;
 }


### PR DESCRIPTION
Fixes #4 